### PR TITLE
CORS: Geoservice API fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -87,7 +87,7 @@ const sortColumns = [
 let selectedFilters = [];
 let data = []; // Declare the data variable as an empty array
 
-// Load Info + Search Stuff 
+// Load Info + Search Stuff
 document.addEventListener('DOMContentLoaded', () => {
 
   function loadNextPage() {
@@ -344,7 +344,7 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(data => {
               totalResults = data.length;
               console.log(totalResults);
-            	searchResultCount.innerHTML = totalResults + ' results found.';
+              searchResultCount.innerHTML = totalResults + ' results found.';
             })
         });
     }
@@ -923,11 +923,11 @@ document.addEventListener('DOMContentLoaded', () => {
       topButton.setAttribute('class', 'bi ' + arrowClass);
     }
   });
-  // BBL to Address conversion 
+  // BBL to Address conversion
   function fetchAddress(block, borough, lot) {
     const url = `https://geoservice.planning.nyc.gov/geoservice/geoservice.svc/Function_BBL?Borough=${borough}&Block=${block}&Lot=${lot}&key=ABDHG7KaPdNahh`;
 
-    fetch(url)
+    fetch(url, { mode: 'no-cors' }) // do not use CORS for this request as it's not supported by the DOB geoservice API
       .then(response => response.json())
       .then(data => {
         const addressRangeList = data.display.AddressRangeList;
@@ -966,14 +966,14 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     document.body.appendChild(script);
   }
- 
+
   // Authenticate the user
   function authenticateUser(callback) {
     gapi.auth2.getAuthInstance().signIn().then(function() {
       callback();
     });
   }
- 
+
   // Open Google Picker to select a sheet
   function openPicker(callback) {
     var picker = new google.picker.PickerBuilder()
@@ -985,7 +985,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .build();
     picker.setVisible(true);
   }
- 
+
   // Export data to the selected sheet
   function exportToGoogleSheets(data, spreadsheetId) {
     gapi.client.sheets.spreadsheets.values.append({
@@ -1001,7 +1001,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.alert('Error exporting data to Google Sheets.');
     });
   }
- 
+
   // Call the functions to load APIs, authenticate user, open picker, and export data
   loadGoogleAPIs(function() {
     authenticateUser(function() {


### PR DESCRIPTION
Disable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for the DOB Geoservice API lookup as it's currently not supported by the API.

Before:
<img width="1470" alt="Screenshot 2023-06-23 at 16 14 08" src="https://github.com/DogDoge0-0/DOB-Permit-Viewer/assets/4038041/fc585eb0-f6dc-4353-a616-2ff417834458">

After:
<img width="1470" alt="Screenshot 2023-06-23 at 16 13 37" src="https://github.com/DogDoge0-0/DOB-Permit-Viewer/assets/4038041/f649f58b-2692-49e8-905f-4ad888a6b64c">


Note: the API key provided seems to not be valid, see the HTTP 401 error.

